### PR TITLE
Add routing with React Router and fade transitions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,11 @@
       "name": "lf-transparency-portal",
       "version": "0.0.0",
       "dependencies": {
+        "framer-motion": "^12.23.12",
         "lucide-react": "^0.539.0",
         "react": "^19.1.1",
-        "react-dom": "^19.1.1"
+        "react-dom": "^19.1.1",
+        "react-router-dom": "^7.8.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.32.0",
@@ -2123,6 +2125,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2617,6 +2628,33 @@
         "url": "https://github.com/sponsors/rawify"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.23.12",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.23.12.tgz",
+      "integrity": "sha512-6e78rdVtnBvlEVgu6eFEAgG9v3wLnYEboM8I5O5EXvfKC8gxGQB8wXJdhkMy10iVcn05jl6CNw7/HTsTCfwcWg==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.23.12",
+        "motion-utils": "^12.23.6",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -3097,6 +3135,21 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/motion-dom": {
+      "version": "12.23.12",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.23.12.tgz",
+      "integrity": "sha512-RcR4fvMCTESQBD/uKQe49D5RUeDOokkGRmz4ceaJKDBgHYtZtntC/s2vLvY38gqGaytinij/yi3hMcWVcEF5Kw==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.23.6"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.23.6",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.23.6.tgz",
+      "integrity": "sha512-eAWoPgr4eFEOFfg2WjIsMoqJTW6Z8MTUCgn/GZ3VRpClWBdnbjryiA3ZSNLyxCTmCQx4RmYX6jX1iWHbenUPNQ==",
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -3572,6 +3625,44 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.8.0.tgz",
+      "integrity": "sha512-r15M3+LHKgM4SOapNmsH3smAizWds1vJ0Z9C4mWaKnT9/wD7+d/0jYcj6LmOvonkrO4Rgdyp4KQ/29gWN2i1eg==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.8.0.tgz",
+      "integrity": "sha512-ntInsnDVnVRdtSu6ODmTQ41cbluak/ENeTif7GBce0L6eztFg6/e1hXAysFQI8X25C8ipKmT9cClbJwxx3Kaqw==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.8.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -3716,6 +3807,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -4067,6 +4164,12 @@
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -11,9 +11,11 @@
   },
   "homepage": "https://vibrantantelope.github.io/lf-transparency-portal/",
   "dependencies": {
+    "framer-motion": "^12.23.12",
     "lucide-react": "^0.539.0",
     "react": "^19.1.1",
-    "react-dom": "^19.1.1"
+    "react-dom": "^19.1.1",
+    "react-router-dom": "^7.8.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.32.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,31 @@
-import TransparencyPortal from "./components/TransparencyPortal";
+import { Routes, Route, useLocation } from 'react-router-dom'
+import { AnimatePresence, motion } from 'framer-motion'
+import TransparencyPortal from './components/TransparencyPortal'
+import MapsPage from './components/MapsPage'
 
 export default function App() {
-  return <TransparencyPortal />;
+  const location = useLocation()
+
+  return (
+    <AnimatePresence mode="wait">
+      <Routes location={location} key={location.pathname}>
+        <Route
+          path="/"
+          element={
+            <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}>
+              <TransparencyPortal />
+            </motion.div>
+          }
+        />
+        <Route
+          path="/maps/*"
+          element={
+            <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}>
+              <MapsPage />
+            </motion.div>
+          }
+        />
+      </Routes>
+    </AnimatePresence>
+  )
 }

--- a/src/components/MapsPage.tsx
+++ b/src/components/MapsPage.tsx
@@ -1,0 +1,8 @@
+export default function MapsPage() {
+  return (
+    <div className="p-6">
+      <h1 className="text-2xl font-semibold mb-4">Maps</h1>
+      <p>Map pages coming soon.</p>
+    </div>
+  )
+}

--- a/src/components/TransparencyPortal.tsx
+++ b/src/components/TransparencyPortal.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useRef, useState } from "react";
+import { Link } from "react-router-dom";
 import { Search, Send, Map as MapIcon, Download, FileText, AlertTriangle, ThumbsUp, ThumbsDown, Loader2, ExternalLink, MessageSquare, ShieldQuestion, ChevronRight, CheckCircle, Link as LinkIcon } from "lucide-react";
 
 import CatalogCard from "./CatalogCard";
@@ -112,7 +113,7 @@ export default function TransparencyPortal() {
           },
         ],
         quickActions: [
-          { label: "Open Zoning Map", href: "#maps", icon: <MapIcon className="w-4 h-4" /> },
+          { label: "Open Zoning Map", href: "/maps/zoning", icon: <MapIcon className="w-4 h-4" /> },
           { label: "Read ordinance", href: "#open-data", icon: <FileText className="w-4 h-4" /> },
         ],
       };
@@ -268,17 +269,29 @@ export default function TransparencyPortal() {
                   {/* Quick actions */}
                   {answer.quickActions?.length ? (
                     <div className="flex flex-wrap gap-2 mt-4">
-                      {answer.quickActions.map((qa, i) => (
-                        <a
-                          key={i}
-                          href={qa.href}
-                          className="inline-flex items-center gap-2 rounded-xl border border-neutral-300 bg-white px-3 py-2 text-sm hover:bg-neutral-100"
-                        >
-                          {qa.icon}
-                          {qa.label}
-                          <ChevronRight className="w-4 h-4" />
-                        </a>
-                      ))}
+                      {answer.quickActions.map((qa, i) =>
+                        qa.href.startsWith("/") ? (
+                          <Link
+                            key={i}
+                            to={qa.href}
+                            className="inline-flex items-center gap-2 rounded-xl border border-neutral-300 bg-white px-3 py-2 text-sm hover:bg-neutral-100"
+                          >
+                            {qa.icon}
+                            {qa.label}
+                            <ChevronRight className="w-4 h-4" />
+                          </Link>
+                        ) : (
+                          <a
+                            key={i}
+                            href={qa.href}
+                            className="inline-flex items-center gap-2 rounded-xl border border-neutral-300 bg-white px-3 py-2 text-sm hover:bg-neutral-100"
+                          >
+                            {qa.icon}
+                            {qa.label}
+                            <ChevronRight className="w-4 h-4" />
+                          </a>
+                        )
+                      )}
                     </div>
                   ) : null}
 
@@ -362,17 +375,17 @@ export default function TransparencyPortal() {
           <h2 className="text-xl font-semibold mb-4">Self‑Serve Maps</h2>
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
             {[
-              { title: "Parcels (Public)", href: "#", desc: "Search parcels; click for assessor link." },
-              { title: "Zoning Map", href: "#", desc: "View zoning districts & ordinance link." },
-              { title: "Construction & Detours", href: "#", desc: "Active capital projects and detours." },
-              { title: "Snow & Sweeping", href: "#", desc: "Plow routes and schedules (public)." },
-              { title: "Tree Canopy & Planting", href: "#", desc: "Coverage and planting opportunities." },
-              { title: "Parks & Trails", href: "#", desc: "Recreation areas and access points." },
+              { title: "Parcels (Public)", to: "/maps/parcels", desc: "Search parcels; click for assessor link." },
+              { title: "Zoning Map", to: "/maps/zoning", desc: "View zoning districts & ordinance link." },
+              { title: "Construction & Detours", to: "/maps/construction", desc: "Active capital projects and detours." },
+              { title: "Snow & Sweeping", to: "/maps/snow", desc: "Plow routes and schedules (public)." },
+              { title: "Tree Canopy & Planting", to: "/maps/trees", desc: "Coverage and planting opportunities." },
+              { title: "Parks & Trails", to: "/maps/parks", desc: "Recreation areas and access points." },
             ].map((m, i) => (
-              <a key={i} href={m.href} className="block rounded-2xl border border-neutral-200 bg-white p-5 shadow-sm hover:shadow-md transition">
+              <Link key={i} to={m.to} className="block rounded-2xl border border-neutral-200 bg-white p-5 shadow-sm hover:shadow-md transition">
                 <div className="font-medium mb-1">{m.title}</div>
                 <div className="text-sm text-neutral-600">{m.desc}</div>
-              </a>
+              </Link>
             ))}
           </div>
         </section>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,13 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import { BrowserRouter } from 'react-router-dom'
 import './index.css'
 import App from './App.tsx'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <BrowserRouter basename="/lf-transparency-portal">
+      <App />
+    </BrowserRouter>
   </StrictMode>,
 )


### PR DESCRIPTION
## Summary
- Install `react-router-dom` and `framer-motion`
- Wrap root in `BrowserRouter` and define routes for `/` and `/maps/*`
- Replace map anchors with `<Link>` and add placeholder Maps page

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6896bfb75394833396cbe1c05053bfbf