### PR TITLE
Add map shell and routing for new maps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "lucide-react": "^0.539.0",
         "react": "^19.1.1",
-        "react-dom": "^19.1.1"
+        "react-dom": "^19.1.1",
+        "react-router-dom": "^6.30.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.32.0",
@@ -1104,6 +1105,15 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.0.tgz",
+      "integrity": "sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -3570,6 +3580,38 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.1.tgz",
+      "integrity": "sha512-X1m21aEmxGXqENEPG3T6u0Th7g0aS4ZmoNynhbs+Cn+q+QGTLt+d5IQ2bHAXKzKcxGJjxACpVbnYQSCRcfxHlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.1.tgz",
+      "integrity": "sha512-llKsgOkZdbPU1Eg3zK8lCn+sjD9wMRZZPuzmdWWX5SUs8OFkN5HnFVC0u5KMeMaC9aoancFI/KoLuKPqN+hxHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0",
+        "react-router": "6.30.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/read-cache": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   "dependencies": {
     "lucide-react": "^0.539.0",
     "react": "^19.1.1",
-    "react-dom": "^19.1.1"
+    "react-dom": "^19.1.1",
+    "react-router-dom": "^6.30.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.32.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,24 @@
+import { BrowserRouter, Routes, Route } from "react-router-dom";
 import TransparencyPortal from "./components/TransparencyPortal";
+import Parcels from "./pages/maps/Parcels";
+import Zoning from "./pages/maps/Zoning";
+import ConstructionDetours from "./pages/maps/ConstructionDetours";
+import SnowSweeping from "./pages/maps/SnowSweeping";
+import TreeCanopy from "./pages/maps/TreeCanopy";
+import ParksTrails from "./pages/maps/ParksTrails";
 
 export default function App() {
-  return <TransparencyPortal />;
+  return (
+    <BrowserRouter>
+      <Routes>
+        <Route path="/" element={<TransparencyPortal />} />
+        <Route path="/maps/parcels" element={<Parcels />} />
+        <Route path="/maps/zoning" element={<Zoning />} />
+        <Route path="/maps/construction-detours" element={<ConstructionDetours />} />
+        <Route path="/maps/snow-sweeping" element={<SnowSweeping />} />
+        <Route path="/maps/tree-canopy" element={<TreeCanopy />} />
+        <Route path="/maps/parks-trails" element={<ParksTrails />} />
+      </Routes>
+    </BrowserRouter>
+  );
 }

--- a/src/components/MapShell.tsx
+++ b/src/components/MapShell.tsx
@@ -1,0 +1,21 @@
+import { Link } from "react-router-dom";
+
+type MapShellProps = {
+  title: string;
+  description?: string;
+};
+
+export default function MapShell({ title, description }: MapShellProps) {
+  return (
+    <div className="p-4">
+      <nav className="mb-4">
+        <Link to="/" className="text-sm text-blue-600 hover:underline">
+          ← Back to Home
+        </Link>
+      </nav>
+      <h1 className="text-2xl font-semibold mb-2">{title}</h1>
+      {description && <p className="text-neutral-600 mb-4">{description}</p>}
+      <div id="map-container" />
+    </div>
+  );
+}

--- a/src/components/TransparencyPortal.tsx
+++ b/src/components/TransparencyPortal.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useRef, useState } from "react";
+import { Link } from "react-router-dom";
 import { Search, Send, Map as MapIcon, Download, FileText, AlertTriangle, ThumbsUp, ThumbsDown, Loader2, ExternalLink, MessageSquare, ShieldQuestion, ChevronRight, CheckCircle, Link as LinkIcon } from "lucide-react";
 
 import CatalogCard from "./CatalogCard";
@@ -362,17 +363,17 @@ export default function TransparencyPortal() {
           <h2 className="text-xl font-semibold mb-4">Self‑Serve Maps</h2>
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
             {[
-              { title: "Parcels (Public)", href: "#", desc: "Search parcels; click for assessor link." },
-              { title: "Zoning Map", href: "#", desc: "View zoning districts & ordinance link." },
-              { title: "Construction & Detours", href: "#", desc: "Active capital projects and detours." },
-              { title: "Snow & Sweeping", href: "#", desc: "Plow routes and schedules (public)." },
-              { title: "Tree Canopy & Planting", href: "#", desc: "Coverage and planting opportunities." },
-              { title: "Parks & Trails", href: "#", desc: "Recreation areas and access points." },
+              { title: "Parcels (Public)", to: "/maps/parcels", desc: "Search parcels; click for assessor link." },
+              { title: "Zoning Map", to: "/maps/zoning", desc: "View zoning districts & ordinance link." },
+              { title: "Construction & Detours", to: "/maps/construction-detours", desc: "Active capital projects and detours." },
+              { title: "Snow & Sweeping", to: "/maps/snow-sweeping", desc: "Plow routes and schedules (public)." },
+              { title: "Tree Canopy & Planting", to: "/maps/tree-canopy", desc: "Coverage and planting opportunities." },
+              { title: "Parks & Trails", to: "/maps/parks-trails", desc: "Recreation areas and access points." },
             ].map((m, i) => (
-              <a key={i} href={m.href} className="block rounded-2xl border border-neutral-200 bg-white p-5 shadow-sm hover:shadow-md transition">
+              <Link key={i} to={m.to} className="block rounded-2xl border border-neutral-200 bg-white p-5 shadow-sm hover:shadow-md transition">
                 <div className="font-medium mb-1">{m.title}</div>
                 <div className="text-sm text-neutral-600">{m.desc}</div>
-              </a>
+              </Link>
             ))}
           </div>
         </section>

--- a/src/pages/maps/ConstructionDetours.tsx
+++ b/src/pages/maps/ConstructionDetours.tsx
@@ -1,0 +1,5 @@
+import MapShell from "../../components/MapShell";
+
+export default function ConstructionDetours() {
+  return <MapShell title="Construction & Detours" />;
+}

--- a/src/pages/maps/Parcels.tsx
+++ b/src/pages/maps/Parcels.tsx
@@ -1,0 +1,5 @@
+import MapShell from "../../components/MapShell";
+
+export default function Parcels() {
+  return <MapShell title="Parcels (Public)" />;
+}

--- a/src/pages/maps/ParksTrails.tsx
+++ b/src/pages/maps/ParksTrails.tsx
@@ -1,0 +1,5 @@
+import MapShell from "../../components/MapShell";
+
+export default function ParksTrails() {
+  return <MapShell title="Parks & Trails" />;
+}

--- a/src/pages/maps/SnowSweeping.tsx
+++ b/src/pages/maps/SnowSweeping.tsx
@@ -1,0 +1,5 @@
+import MapShell from "../../components/MapShell";
+
+export default function SnowSweeping() {
+  return <MapShell title="Snow & Sweeping" />;
+}

--- a/src/pages/maps/TreeCanopy.tsx
+++ b/src/pages/maps/TreeCanopy.tsx
@@ -1,0 +1,5 @@
+import MapShell from "../../components/MapShell";
+
+export default function TreeCanopy() {
+  return <MapShell title="Tree Canopy & Planting" />;
+}

--- a/src/pages/maps/Zoning.tsx
+++ b/src/pages/maps/Zoning.tsx
@@ -1,0 +1,5 @@
+import MapShell from "../../components/MapShell";
+
+export default function Zoning() {
+  return <MapShell title="Zoning Map" />;
+}


### PR DESCRIPTION
## Summary
- add reusable `MapShell` wrapper for map pages with back navigation and container placeholder
- introduce map pages (Parcels, Zoning, Construction & Detours, Snow & Sweeping, Tree Canopy & Planting, Parks & Trails)
- wire React Router and update map list to link to new routes

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6896bfc1b1f483339f248e865148e87a