### PR TITLE
Add MapShell component and placeholder map pages

### DIFF
--- a/src/components/MapShell.tsx
+++ b/src/components/MapShell.tsx
@@ -1,0 +1,21 @@
+import { Link } from "react-router-dom";
+
+interface MapShellProps {
+  title: string;
+  description?: string;
+}
+
+export default function MapShell({ title, description }: MapShellProps) {
+  return (
+    <div className="p-6">
+      <nav className="mb-4">
+        <Link to="/" className="text-sm text-blue-600 hover:underline">
+          &larr; Back to Home
+        </Link>
+      </nav>
+      <h1 className="text-2xl font-semibold mb-2">{title}</h1>
+      {description && <p className="text-neutral-600 mb-4">{description}</p>}
+      <div id="map-container" className="w-full h-96 bg-neutral-100 rounded" />
+    </div>
+  );
+}

--- a/src/components/MapsPage.tsx
+++ b/src/components/MapsPage.tsx
@@ -1,8 +1,29 @@
+import { Routes, Route } from "react-router-dom";
+import Parcels from "../pages/maps/Parcels";
+import Zoning from "../pages/maps/Zoning";
+import ConstructionDetours from "../pages/maps/ConstructionDetours";
+import SnowSweeping from "../pages/maps/SnowSweeping";
+import TreeCanopy from "../pages/maps/TreeCanopy";
+import ParksTrails from "../pages/maps/ParksTrails";
+
 export default function MapsPage() {
   return (
-    <div className="p-6">
-      <h1 className="text-2xl font-semibold mb-4">Maps</h1>
-      <p>Map pages coming soon.</p>
-    </div>
-  )
+    <Routes>
+      <Route
+        index
+        element={
+          <div className="p-6">
+            <h1 className="text-2xl font-semibold mb-4">Maps</h1>
+            <p>Map pages coming soon.</p>
+          </div>
+        }
+      />
+      <Route path="parcels" element={<Parcels />} />
+      <Route path="zoning" element={<Zoning />} />
+      <Route path="construction" element={<ConstructionDetours />} />
+      <Route path="snow" element={<SnowSweeping />} />
+      <Route path="trees" element={<TreeCanopy />} />
+      <Route path="parks" element={<ParksTrails />} />
+    </Routes>
+  );
 }

--- a/src/pages/maps/ConstructionDetours.tsx
+++ b/src/pages/maps/ConstructionDetours.tsx
@@ -1,0 +1,5 @@
+import MapShell from "../../components/MapShell";
+
+export default function ConstructionDetours() {
+  return <MapShell title="Construction & Detours" />;
+}

--- a/src/pages/maps/Parcels.tsx
+++ b/src/pages/maps/Parcels.tsx
@@ -1,0 +1,5 @@
+import MapShell from "../../components/MapShell";
+
+export default function Parcels() {
+  return <MapShell title="Parcels (Public)" />;
+}

--- a/src/pages/maps/ParksTrails.tsx
+++ b/src/pages/maps/ParksTrails.tsx
@@ -1,0 +1,5 @@
+import MapShell from "../../components/MapShell";
+
+export default function ParksTrails() {
+  return <MapShell title="Parks & Trails" />;
+}

--- a/src/pages/maps/SnowSweeping.tsx
+++ b/src/pages/maps/SnowSweeping.tsx
@@ -1,0 +1,5 @@
+import MapShell from "../../components/MapShell";
+
+export default function SnowSweeping() {
+  return <MapShell title="Snow & Sweeping" />;
+}

--- a/src/pages/maps/TreeCanopy.tsx
+++ b/src/pages/maps/TreeCanopy.tsx
@@ -1,0 +1,5 @@
+import MapShell from "../../components/MapShell";
+
+export default function TreeCanopy() {
+  return <MapShell title="Tree Canopy & Planting" />;
+}

--- a/src/pages/maps/Zoning.tsx
+++ b/src/pages/maps/Zoning.tsx
@@ -1,0 +1,5 @@
+import MapShell from "../../components/MapShell";
+
+export default function Zoning() {
+  return <MapShell title="Zoning Map" />;
+}


### PR DESCRIPTION
## Summary
- add reusable `MapShell` with title, description, and back link
- create placeholder map pages that render `MapShell`
- wire `/maps/*` routes to new pages

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6896c1389bf08333a6e1a897630914a8