### PR TITLE
feat: add FOIA Commons page and route

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { Routes, Route, useLocation } from 'react-router-dom'
 import { AnimatePresence, motion } from 'framer-motion'
 import TransparencyPortal from './components/TransparencyPortal'
 import MapsPage from './components/MapsPage'
+import FoiaCommonsPage from './pages/foia-commons'
 
 export default function App() {
   const location = useLocation()
@@ -17,6 +18,7 @@ export default function App() {
             </motion.div>
           }
         />
+        <Route path="/foia-commons" element={<FoiaCommonsPage />} />
         <Route
           path="/maps/*"
           element={

--- a/src/pages/foia-commons/index.tsx
+++ b/src/pages/foia-commons/index.tsx
@@ -1,0 +1,8 @@
+export default function FoiaCommonsPage() {
+  return (
+    <div className="p-6">
+      <h1 className="text-2xl font-semibold mb-4">FOIA Commons</h1>
+      <p>Content coming soon.</p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add placeholder FOIA Commons page
- expose FOIA Commons at `/foia-commons`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68973bceb2088333aee1cd1a0e1c4acd